### PR TITLE
Fix Roslyn codegen and document CLI usage

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -33,3 +33,19 @@ Ryn-lang.sln                 // The main solution file
 
 ## Getting Started
 
+To compile a Ryn source file and execute the generated C# code, use the CLI:
+
+```bash
+dotnet run --project Ryn-lang/Ryn.CLI -f path/to/file.ryn
+```
+
+The example below prints a greeting:
+
+```ryn
+pub class Hello {
+    pub fn greet() {
+        Print("Hello from Ryn!");
+    }
+}
+```
+

--- a/Ryn-lang/Ryn.CodeGen/RoslynCompiler.cs
+++ b/Ryn-lang/Ryn.CodeGen/RoslynCompiler.cs
@@ -14,12 +14,25 @@ namespace Ryn.CodeGen
     {
         public void CompileAndRun(CompilationUnitSyntax syntaxTree)
         {
+            // Basic metadata references so Roslyn can compile a runnable assembly
+            var references = new[]
+            {
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(Console).Assembly.Location)
+            };
+
             var compilation = CSharpCompilation.Create("Generated")
                 .WithOptions(new CSharpCompilationOptions(OutputKind.ConsoleApplication))
+                .AddReferences(references)
                 .AddSyntaxTrees(SyntaxFactory.SyntaxTree(syntaxTree));
 
             using var ms = new MemoryStream();
-            compilation.Emit(ms);
+            var emitResult = compilation.Emit(ms);
+            if (!emitResult.Success)
+            {
+                var message = string.Join("\n", emitResult.Diagnostics.Select(d => d.ToString()));
+                throw new InvalidOperationException($"Compilation failed:\n{message}");
+            }
             ms.Seek(0, SeekOrigin.Begin);
             var assembly = Assembly.Load(ms.ToArray());
             assembly.EntryPoint?.Invoke(null, null);

--- a/Ryn-lang/Ryn.CodeGen/RynAstToCSharpVisitor.cs
+++ b/Ryn-lang/Ryn.CodeGen/RynAstToCSharpVisitor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Ryn.AST;
 using System;
@@ -20,9 +21,45 @@ namespace Ryn.CodeGen
 
         private ClassDeclarationSyntax VisitClass(ClassNode node)
         {
-            return SyntaxFactory.ClassDeclaration(node.Name)
-                .AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword));
+            var classDecl = SyntaxFactory.ClassDeclaration(node.Name)
+                .AddModifiers(ToModifier(node.AccessModifier));
+
+            var methods = node.Methods.Select(VisitMethod).ToArray();
+            return classDecl.AddMembers(methods);
         }
+
+        private MemberDeclarationSyntax VisitMethod(MethodNode node)
+        {
+            var method = SyntaxFactory.MethodDeclaration(
+                    SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.VoidKeyword)),
+                    node.Name)
+                .AddModifiers(ToModifier(node.AccessModifier))
+                .WithBody(SyntaxFactory.Block(node.Body.Select(VisitStatement)));
+            return method;
+        }
+
+        private StatementSyntax VisitStatement(AstNode node) => node switch
+        {
+            PrintNode print => SyntaxFactory.ExpressionStatement(
+                SyntaxFactory.InvocationExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("Console"),
+                        SyntaxFactory.IdentifierName("WriteLine")))
+                    .WithArgumentList(
+                        SyntaxFactory.ArgumentList(
+                            SyntaxFactory.SingletonSeparatedList(
+                                SyntaxFactory.Argument(SyntaxFactory.ParseExpression(print.Content)))))),
+            _ => SyntaxFactory.EmptyStatement()
+        };
+
+        private static SyntaxToken ToModifier(string mod) => mod switch
+        {
+            "pub" => SyntaxFactory.Token(SyntaxKind.PublicKeyword),
+            "priv" => SyntaxFactory.Token(SyntaxKind.PrivateKeyword),
+            "prot" => SyntaxFactory.Token(SyntaxKind.ProtectedKeyword),
+            _ => SyntaxFactory.Token(SyntaxKind.PublicKeyword)
+        };
     }
 
 }


### PR DESCRIPTION
## Summary
- extend the Roslyn visitor to generate methods and print statements
- add compilation references and diagnostics in the Roslyn compiler
- document how to run the CLI

## Testing
- `dotnet test` *(fails: `dotnet` not found)*